### PR TITLE
Refine reconnect procedure

### DIFF
--- a/src/actions/relay.mjs
+++ b/src/actions/relay.mjs
@@ -68,10 +68,16 @@ export function init(relayUrl, prikey) {
   botPrivateKeyHex = prikey;
 
   relay = nostrTool.relayInit(relayUrl);
-  relay.on("error", () => {
-    logger.error("Failed to connect. ");
-    finalize();
-    return false;
+  relay.on('connect', () => {
+    logger.info(`Relay connected to ${relay.url}`);
+  });
+  relay.on('error', () => {
+    logger.error(`Relay encountered error!! ${relay.url}`);
+    process.exit(1);
+  });
+  relay.on('disconnect', () => {
+    logger.info(`Relay is disconnected. ${relay.url}`);
+    process.exit(1);
   });
 
   logger.debug("init success!");


### PR DESCRIPTION
This commit enhances error handling and reporting for the relay WebSocket connection in `relay.mjs`. Previously, the 'error' event only logged a generic error message and ran the `finalize()` function. Now, it logs a more descriptive error message including the relay's URL, and then it forces the process to exit with a status code of 1, indicating a general error.

Furthermore, two additional event handlers were added. 

The 'connect' event handler logs a message confirming the successful connection to the relay's URL.

The 'disconnect' event handler logs a message about the disconnection, includes the relay's URL, and terminates the process with a status code of 1, just as the 'error' event handler does.

These changes should provide better visibility into the connection's state and more information when errors occur.
